### PR TITLE
fix(PythonCollector): error for unexpected result

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![documentation](https://img.shields.io/badge/docs-mkdocs%20material-blue.svg?style=flat)](https://mkdocstrings.github.io/python-legacy/)
 [![pypi version](https://img.shields.io/pypi/v/mkdocstrings-python-legacy.svg)](https://pypi.org/project/mkdocstrings-python-legacy/)
 [![gitpod](https://img.shields.io/badge/gitpod-workspace-blue.svg?style=flat)](https://gitpod.io/#https://github.com/mkdocstrings/python-legacy)
-[![gitter](https://badges.gitter.im/join%20chat.svg)](https://gitter.im/mkdocstrings/community)
+[![gitter](https://badges.gitter.im/join%20chat.svg)](https://gitter.im/mkdocstrings/python-legacy)
 
 A legacy Python handler for mkdocstrings.
 

--- a/src/mkdocstrings/handlers/python/collector.py
+++ b/src/mkdocstrings/handlers/python/collector.py
@@ -152,8 +152,8 @@ class PythonCollector(BaseCollector):
             error = "\n".join(("Error while loading JSON:", stdout, traceback.format_exc()))
             raise CollectionError(error) from exception
 
-        error = result.get("error")
-        if error:
+        if "error" in result:
+            error = result["error"]
             if "traceback" in result:
                 error += f"\n{result['traceback']}"
             raise CollectionError(error)

--- a/src/mkdocstrings/handlers/python/collector.py
+++ b/src/mkdocstrings/handlers/python/collector.py
@@ -158,15 +158,15 @@ class PythonCollector(BaseCollector):
                 error += f"\n{result['traceback']}"
             raise CollectionError(error)
 
-        for loading_error in result.get("loading_errors", []):
+        for loading_error in result["loading_errors"]:
             log.warning(loading_error)
 
-        for errors in result.get("parsing_errors", {}).values():
+        for errors in result["parsing_errors"].values():
             for parsing_error in errors:
                 log.warning(parsing_error)
 
         # We always collect only one object at a time
-        result = result.get("objects", [{}])[0]
+        result = result["objects"][0]
 
         log.debug("Rebuilding categories and children lists")
         rebuild_category_lists(result)

--- a/src/mkdocstrings/handlers/python/collector.py
+++ b/src/mkdocstrings/handlers/python/collector.py
@@ -158,15 +158,15 @@ class PythonCollector(BaseCollector):
                 error += f"\n{result['traceback']}"
             raise CollectionError(error)
 
-        for loading_error in result["loading_errors"]:
+        for loading_error in result.get("loading_errors", []):
             log.warning(loading_error)
 
-        for errors in result["parsing_errors"].values():
+        for errors in result.get("parsing_errors", {}).values():
             for parsing_error in errors:
                 log.warning(parsing_error)
 
         # We always collect only one object at a time
-        result = result["objects"][0]
+        result = result.get("objects", [{}])[0]
 
         log.debug("Rebuilding categories and children lists")
         rebuild_category_lists(result)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+
+from mkdocstrings.handlers.base import CollectionError
+from mkdocstrings.handlers.python import collector
+
+
+def test_init():
+    collector.PythonCollector()
+
+
+def test_collect():
+    obj = collector.PythonCollector()
+    with pytest.raises(CollectionError):
+        obj.collect("", {})

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -18,6 +18,7 @@ def test_init():
     (
         ({"error": "error1", "traceback": "hello"}, "error1\nhello"),
         ({"error": "error1"}, "error1"),
+        ({"error": "", "traceback": "hello"}, "\nhello"),
     ),
 )
 def test_collect_result_error(retval, exp_res):

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import json
+"""test for mkdocstrings.handlers.python.collector."""
 from unittest import mock
 
 import pytest
@@ -10,22 +9,28 @@ from mkdocstrings.handlers.python import collector
 
 
 def test_init():
+    """Test init for collector.PythonCollector."""
     assert collector.PythonCollector()
 
 
 @pytest.mark.parametrize(
-    "retval, exp_res",
-    (
+    ("retval", "exp_res"),
+    [
         ({"error": "error1", "traceback": "hello"}, "error1\nhello"),
         ({"error": "error1"}, "error1"),
         ({"error": "", "traceback": "hello"}, "\nhello"),
-    ),
+    ],
 )
 def test_collect_result_error(retval, exp_res):
-    with mock.patch("mkdocstrings.handlers.python.collector.json.loads") as m_loads, pytest.raises(
-        CollectionError
-    ) as excinfo:
-        m_loads.return_value = retval
-        obj = collector.PythonCollector()
-        assert obj.collect("", {})
-    assert str(excinfo.value) == exp_res
+    """Test collector.PythonCollector when result return error.
+
+    Args:
+        retval: return value to mock json.loads
+        exp_res: expected result
+    """
+    with mock.patch("mkdocstrings.handlers.python.collector.json.loads") as m_loads:
+        with pytest.raises(CollectionError) as excinfo:  # noqa: PT012
+            m_loads.return_value = retval
+            obj = collector.PythonCollector()
+            assert obj.collect("", {})
+            assert str(excinfo.value) == exp_res

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""test for mkdocstrings.handlers.python.collector."""
+"""Tests for the `collector` module."""
 from unittest import mock
 
 import pytest

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -25,8 +25,8 @@ def test_collect_result_error(retval, exp_res):
     """Test handling of errors when collecting an object.
 
     Args:
-        retval: return value to mock json.loads
-        exp_res: expected result
+        retval: Return value to mock `json.loads` with.
+        exp_res: Expected result.
     """
     with mock.patch("mkdocstrings.handlers.python.collector.json.loads") as m_loads:
         with pytest.raises(CollectionError) as excinfo:  # noqa: PT012

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import json
+from unittest import mock
+
 import pytest
 
 from mkdocstrings.handlers.base import CollectionError
@@ -10,7 +13,18 @@ def test_init():
     collector.PythonCollector()
 
 
-def test_collect():
-    obj = collector.PythonCollector()
-    with pytest.raises(CollectionError):
-        obj.collect("", {})
+@pytest.mark.parametrize(
+    "retval, exp_res",
+    (
+        ({"error": "error1", "traceback": "hello"}, "error1\nhello"),
+        ({"error": "error1"}, "error1"),
+    ),
+)
+def test_collect_result_error(retval, exp_res):
+    with mock.patch("mkdocstrings.handlers.python.collector.json.loads") as m_loads, pytest.raises(
+        CollectionError
+    ) as excinfo:
+        m_loads.return_value = retval
+        obj = collector.PythonCollector()
+        assert obj.collect("", {})
+    assert str(excinfo.value) == exp_res

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -22,7 +22,7 @@ def test_init():
     ],
 )
 def test_collect_result_error(retval, exp_res):
-    """Test collector.PythonCollector when result return error.
+    """Test handling of errors when collecting an object.
 
     Args:
         retval: return value to mock json.loads


### PR DESCRIPTION
this is fix for several error i got when trying mkdocs on https://github.com/iamtalhaasghar/yewtube

in the end i still don't know what to change when rebuild_category_lists handle empty dict

## legacy error 1

```python
ERROR    -  Error reading page 'reference/config.md': 'loading_errors'
Traceback (most recent call last):
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
    │        └ <Group cli>
    └ <module 'sys' (built-in)>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
           │          │       └ {}
           │          └ ()
           └ <Group cli>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
         │           └ <click.core.Context object at 0x7f25a8c0c1c0>
         └ <Group cli>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
           │               │                      └ <click.core.Context object at 0x7f25a8f10c40>
           │               └ <click.core.Context object at 0x7f25a8f10c40>
           └ <function MultiCommand.invoke.<locals>._process_result at 0x7f25a8f8d040>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           │          │                └ <click.core.Context object at 0x7f25a8f10c40>
           │          └ <Command serve>
           └ <click.core.Context object at 0x7f25a8f10c40>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
                       │       └ {'dev_addr': None, 'livereload': 'livereload', 'watch_theme': False, 'config_file': None, 'strict': None, 'theme': None, 'use_di...
                       └ ()
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/__main__.py", line 177, in serve_command
    serve.serve(dev_addr=dev_addr, livereload=livereload, **kwargs)
    │                    │                    │             └ {'watch_theme': False, 'config_file': None, 'strict': None, 'theme': None, 'use_directory_urls': None}
    │                    │                    └ 'livereload'
    │                    └ None
    └ <module 'mkdocs.commands.serve' from '/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/m...
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/serve.py", line 54, in serve
    config = builder()
             └ <function serve.<locals>.builder at 0x7f25a7c4b670>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/serve.py", line 49, in builder
    build(config, live_server=live_server, dirty=dirty)
    │     │                   │                  └ False
    │     │                   └ True
    │     └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    └ <function build at 0x7f25a7f25f70>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/build.py", line 292, in build
    _populate_page(file.page, config, files, dirty)
    │              │          │       │      └ False
    │              │          │       └ <mkdocs.structure.files.Files object at 0x7f25a778f970>
    │              │          └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    │              └ File(src_path='reference/config.md', dest_path='reference/config/index.html', name='config', url='reference/config/')
    └ <function _populate_page at 0x7f25a7f25e50>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/build.py", line 174, in _populate_page
    page.render(config, files)
    │           │       └ <mkdocs.structure.files.Files object at 0x7f25a778f970>
    │           └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    └ Page(title='Config', url='/yewtube/reference/config/')
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/structure/pages.py", line 174, in render
    self.content = md.convert(self.markdown)
    │              │          └ Page(title='Config', url='/yewtube/reference/config/')
    │              └ <markdown.core.Markdown object at 0x7f25a7792f10>
    └ Page(title='Config', url='/yewtube/reference/config/')
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/core.py", line 264, in convert
    root = self.parser.parseDocument(self.lines).getroot()
           │                         └ <markdown.core.Markdown object at 0x7f25a7792f10>
           └ <markdown.core.Markdown object at 0x7f25a7792f10>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 90, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
    │               │                    └ ['::: mps_youtube.config', '', '', '']
    │               └ <markdown.blockparser.BlockParser object at 0x7f25a7627340>
    └ <markdown.blockparser.BlockParser object at 0x7f25a7627340>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 105, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
    │                │       └ '::: mps_youtube.config\n\n\n'
    │                └ <Element 'div' at 0x7f25a76091d0>
    └ <markdown.blockparser.BlockParser object at 0x7f25a7627340>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 123, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/extension.py", line 120, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
                          │                   │           │      └ 0
                          │                   │           └ ''
                          │                   └ 'mps_youtube.config'
                          └ <mkdocstrings.extension.AutoDocProcessor object at 0x7f25a7be4070>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/extension.py", line 185, in _process_block
    data: CollectorItem = handler.collector.collect(identifier, selection)
          │               │                         │           └ ChainMap({}, {})
          │               │                         └ 'mps_youtube.config'
          │               └ <mkdocstrings.handlers.python.PythonHandler object at 0x7f25a751db50>
          └ typing.Any
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/handlers/python/collector.py", line 161, in collect
    for loading_error in result["loading_errors"]:
KeyError: 'loading_errors'
```
## legacy error 2

```python
ERROR    -  Error reading page 'reference/config.md': 'parsing_errors'
Traceback (most recent call last):
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
    │        └ <Group cli>
    └ <module 'sys' (built-in)>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
           │          │       └ {}
           │          └ ()
           └ <Group cli>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
         │           └ <click.core.Context object at 0x7fd77c7ab1c0>
         └ <Group cli>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
           │               │                      └ <click.core.Context object at 0x7fd77caafc40>
           │               └ <click.core.Context object at 0x7fd77caafc40>
           └ <function MultiCommand.invoke.<locals>._process_result at 0x7fd77cb2c040>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           │          │                └ <click.core.Context object at 0x7fd77caafc40>
           │          └ <Command serve>
           └ <click.core.Context object at 0x7fd77caafc40>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
                       │       └ {'dev_addr': None, 'livereload': 'livereload', 'watch_theme': False, 'config_file': None, 'strict': None, 'theme': None, 'use_di...
                       └ ()
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/__main__.py", line 177, in serve_command
    serve.serve(dev_addr=dev_addr, livereload=livereload, **kwargs)
    │                    │                    │             └ {'watch_theme': False, 'config_file': None, 'strict': None, 'theme': None, 'use_directory_urls': None}
    │                    │                    └ 'livereload'
    │                    └ None
    └ <module 'mkdocs.commands.serve' from '/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/m...
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/serve.py", line 54, in serve
    config = builder()
             └ <function serve.<locals>.builder at 0x7fd77b7db670>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/serve.py", line 49, in builder
    build(config, live_server=live_server, dirty=dirty)
    │     │                   │                  └ False
    │     │                   └ True
    │     └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    └ <function build at 0x7fd77bac5f70>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/build.py", line 292, in build
    _populate_page(file.page, config, files, dirty)
    │              │          │       │      └ False
    │              │          │       └ <mkdocs.structure.files.Files object at 0x7fd77b32f910>
    │              │          └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    │              └ File(src_path='reference/config.md', dest_path='reference/config/index.html', name='config', url='reference/config/')
    └ <function _populate_page at 0x7fd77bac5e50>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/build.py", line 174, in _populate_page
    page.render(config, files)
    │           │       └ <mkdocs.structure.files.Files object at 0x7fd77b32f910>
    │           └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    └ Page(title='Config', url='/yewtube/reference/config/')
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/structure/pages.py", line 174, in render
    self.content = md.convert(self.markdown)
    │              │          └ Page(title='Config', url='/yewtube/reference/config/')
    │              └ <markdown.core.Markdown object at 0x7fd77b331460>
    └ Page(title='Config', url='/yewtube/reference/config/')
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/core.py", line 264, in convert
    root = self.parser.parseDocument(self.lines).getroot()
           │                         └ <markdown.core.Markdown object at 0x7fd77b331460>
           └ <markdown.core.Markdown object at 0x7fd77b331460>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 90, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
    │               │                    └ ['::: mps_youtube.config', '', '', '']
    │               └ <markdown.blockparser.BlockParser object at 0x7fd77b2c5070>
    └ <markdown.blockparser.BlockParser object at 0x7fd77b2c5070>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 105, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
    │                │       └ '::: mps_youtube.config\n\n\n'
    │                └ <Element 'div' at 0x7fd77b1e5360>
    └ <markdown.blockparser.BlockParser object at 0x7fd77b2c5070>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 123, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/extension.py", line 120, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
                          │                   │           │      └ 0
                          │                   │           └ ''
                          │                   └ 'mps_youtube.config'
                          └ <mkdocstrings.extension.AutoDocProcessor object at 0x7fd77b783640>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/extension.py", line 185, in _process_block
    data: CollectorItem = handler.collector.collect(identifier, selection)
          │               │                         │           └ ChainMap({}, {})
          │               │                         └ 'mps_youtube.config'
          │               └ <mkdocstrings.handlers.python.PythonHandler object at 0x7fd77b0bbb20>
          └ typing.Any
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/handlers/python/collector.py", line 164, in collect
    for errors in result["parsing_errors"].values():
KeyError: 'parsing_errors'
```

## legacy error 3

```python
ERROR    -  Error reading page 'reference/config.md': 'objects'
Traceback (most recent call last):
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
    │        └ <Group cli>
    └ <module 'sys' (built-in)>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
           │          │       └ {}
           │          └ ()
           └ <Group cli>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
         │           └ <click.core.Context object at 0x7f159dedc1c0>
         └ <Group cli>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
           │               │                      └ <click.core.Context object at 0x7f159cf15940>
           │               └ <click.core.Context object at 0x7f159cf15940>
           └ <function MultiCommand.invoke.<locals>._process_result at 0x7f159e25d040>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           │          │                └ <click.core.Context object at 0x7f159cf15940>
           │          └ <Command serve>
           └ <click.core.Context object at 0x7f159cf15940>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
                       │       └ {'dev_addr': None, 'livereload': 'livereload', 'watch_theme': False, 'config_file': None, 'strict': None, 'theme': None, 'use_di...
                       └ ()
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/__main__.py", line 177, in serve_command
    serve.serve(dev_addr=dev_addr, livereload=livereload, **kwargs)
    │                    │                    │             └ {'watch_theme': False, 'config_file': None, 'strict': None, 'theme': None, 'use_directory_urls': None}
    │                    │                    └ 'livereload'
    │                    └ None
    └ <module 'mkdocs.commands.serve' from '/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/m...
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/serve.py", line 54, in serve
    config = builder()
             └ <function serve.<locals>.builder at 0x7f159cf0c670>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/serve.py", line 49, in builder
    build(config, live_server=live_server, dirty=dirty)
    │     │                   │                  └ False
    │     │                   └ True
    │     └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    └ <function build at 0x7f159d1f5f70>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/build.py", line 292, in build
    _populate_page(file.page, config, files, dirty)
    │              │          │       │      └ False
    │              │          │       └ <mkdocs.structure.files.Files object at 0x7f159ca5f8b0>
    │              │          └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    │              └ File(src_path='reference/config.md', dest_path='reference/config/index.html', name='config', url='reference/config/')
    └ <function _populate_page at 0x7f159d1f5e50>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/build.py", line 174, in _populate_page
    page.render(config, files)
    │           │       └ <mkdocs.structure.files.Files object at 0x7f159ca5f8b0>
    │           └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    └ Page(title='Config', url='/yewtube/reference/config/')
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/structure/pages.py", line 174, in render
    self.content = md.convert(self.markdown)
    │              │          └ Page(title='Config', url='/yewtube/reference/config/')
    │              └ <markdown.core.Markdown object at 0x7f159c85c610>
    └ Page(title='Config', url='/yewtube/reference/config/')
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/core.py", line 264, in convert
    root = self.parser.parseDocument(self.lines).getroot()
           │                         └ <markdown.core.Markdown object at 0x7f159c85c610>
           └ <markdown.core.Markdown object at 0x7f159c85c610>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 90, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
    │               │                    └ ['::: mps_youtube.config', '', '', '']
    │               └ <markdown.blockparser.BlockParser object at 0x7f159c85c2e0>
    └ <markdown.blockparser.BlockParser object at 0x7f159c85c2e0>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 105, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
    │                │       └ '::: mps_youtube.config\n\n\n'
    │                └ <Element 'div' at 0x7f159c918590>
    └ <markdown.blockparser.BlockParser object at 0x7f159c85c2e0>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 123, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/extension.py", line 120, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
                          │                   │           │      └ 0
                          │                   │           └ ''
                          │                   └ 'mps_youtube.config'
                          └ <mkdocstrings.extension.AutoDocProcessor object at 0x7f159c82c6a0>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/extension.py", line 185, in _process_block
    data: CollectorItem = handler.collector.collect(identifier, selection)
          │               │                         │           └ ChainMap({}, {})
          │               │                         └ 'mps_youtube.config'
          │               └ <mkdocstrings.handlers.python.PythonHandler object at 0x7f159c7eca90>
          └ typing.Any
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/handlers/python/collector.py", line 169, in collect
    result = result["objects"][0]
    │        └ {'error': '', 'traceback': 'Traceback (most recent call last):\n  File "/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewt...
    └ {'error': '', 'traceback': 'Traceback (most recent call last):\n  File "/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewt...
KeyError: 'objects'
```
## legacy error 4
```python
ERROR    -  Error reading page 'reference/config.md': 'attributes'
Traceback (most recent call last):
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
    │        └ <Group cli>
    └ <module 'sys' (built-in)>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
           │          │       └ {}
           │          └ ()
           └ <Group cli>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
         │           └ <click.core.Context object at 0x7fbae3b0d1c0>
         └ <Group cli>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
           │               │                      └ <click.core.Context object at 0x7fbae3e11c40>
           │               └ <click.core.Context object at 0x7fbae3e11c40>
           └ <function MultiCommand.invoke.<locals>._process_result at 0x7fbae3e8e040>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           │          │                └ <click.core.Context object at 0x7fbae3e11c40>
           │          └ <Command serve>
           └ <click.core.Context object at 0x7fbae3e11c40>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
                       │       └ {'dev_addr': None, 'livereload': 'livereload', 'watch_theme': False, 'config_file': None, 'strict': None, 'theme': None, 'use_di...
                       └ ()
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/__main__.py", line 177, in serve_command
    serve.serve(dev_addr=dev_addr, livereload=livereload, **kwargs)
    │                    │                    │             └ {'watch_theme': False, 'config_file': None, 'strict': None, 'theme': None, 'use_directory_urls': None}
    │                    │                    └ 'livereload'
    │                    └ None
    └ <module 'mkdocs.commands.serve' from '/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/m...
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/serve.py", line 54, in serve
    config = builder()
             └ <function serve.<locals>.builder at 0x7fbae2b3d670>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/serve.py", line 49, in builder
    build(config, live_server=live_server, dirty=dirty)
    │     │                   │                  └ False
    │     │                   └ True
    │     └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    └ <function build at 0x7fbae2e28f70>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/build.py", line 292, in build
    _populate_page(file.page, config, files, dirty)
    │              │          │       │      └ False
    │              │          │       └ <mkdocs.structure.files.Files object at 0x7fbae26909a0>
    │              │          └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    │              └ File(src_path='reference/config.md', dest_path='reference/config/index.html', name='config', url='reference/config/')
    └ <function _populate_page at 0x7fbae2e28e50>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/commands/build.py", line 174, in _populate_page
    page.render(config, files)
    │           │       └ <mkdocs.structure.files.Files object at 0x7fbae26909a0>
    │           └ {'config_file_path': '/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/yewtube/mkdocs.yml', 'site_name': 'Yewtube', 'nav': [{...
    └ Page(title='Config', url='/yewtube/reference/config/')
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocs/structure/pages.py", line 174, in render
    self.content = md.convert(self.markdown)
    │              │          └ Page(title='Config', url='/yewtube/reference/config/')
    │              └ <markdown.core.Markdown object at 0x7fbae248b520>
    └ Page(title='Config', url='/yewtube/reference/config/')
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/core.py", line 264, in convert
    root = self.parser.parseDocument(self.lines).getroot()
           │                         └ <markdown.core.Markdown object at 0x7fbae248b520>
           └ <markdown.core.Markdown object at 0x7fbae248b520>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 90, in parseDocument
    self.parseChunk(self.root, '\n'.join(lines))
    │               │                    └ ['::: mps_youtube.config', '', '', '']
    │               └ <markdown.blockparser.BlockParser object at 0x7fbae24e8a30>
    └ <markdown.blockparser.BlockParser object at 0x7fbae24e8a30>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 105, in parseChunk
    self.parseBlocks(parent, text.split('\n\n'))
    │                │       └ '::: mps_youtube.config\n\n\n'
    │                └ <Element 'div' at 0x7fbae2547e50>
    └ <markdown.blockparser.BlockParser object at 0x7fbae24e8a30>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/markdown/blockparser.py", line 123, in parseBlocks
    if processor.run(parent, blocks) is not False:
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/extension.py", line 120, in run
    html, handler, data = self._process_block(identifier, block, heading_level)
                          │                   │           │      └ 0
                          │                   │           └ ''
                          │                   └ 'mps_youtube.config'
                          └ <mkdocstrings.extension.AutoDocProcessor object at 0x7fbae2ae5490>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/extension.py", line 185, in _process_block
    data: CollectorItem = handler.collector.collect(identifier, selection)
          │               │                         │           └ ChainMap({}, {})
          │               │                         └ 'mps_youtube.config'
          │               └ <mkdocstrings.handlers.python.PythonHandler object at 0x7fbae241cb20>
          └ typing.Any
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/handlers/python/collector.py", line 172, in collect
    rebuild_category_lists(result)
    │                      └ {}
    └ <function rebuild_category_lists at 0x7fbae265cdc0>
  File "/home/r3r/.cache/pypoetry/virtualenvs/yewtube-kzulWQkH-py3.9/lib/python3.9/site-packages/mkdocstrings/handlers/python/collector.py", line 198, in rebuild_category_lists
    obj[category] = [obj["children"][path] for path in obj[category]]
    │   │            │                                 │   └ 'attributes'
    │   │            │                                 └ {}
    │   │            └ {}
    │   └ 'attributes'
    └ {}
KeyError: 'attributes'
```
